### PR TITLE
Changed the respec URL to be relative

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
 <head>
   <title>Server Timing</title>
   <meta charset='utf-8'>
-  <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
     shortName: "server-timing",
     specStatus: "FPWD",
-    edDraftURI: "http://w3c.github.io/server-timing/",
+    edDraftURI: "https://w3c.github.io/server-timing/",
     publishDate: "2015-02-17",
     editors: [{
       name: "Ilya Grigorik",


### PR DESCRIPTION
The draft on github.io seems to be broken (read: respec doesn't run) in Chrome due to mixed content scripts being blocked.
I simply changed the respec URL to be schema relative.