### PR TITLE
fix example

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,21 +255,16 @@ Server must return the `Timing-Allow-Origin` HTTP response header, as defined in
 
   <pre class="example js">
     // Gather server timing for a particular resource
-    const serverTimings = window.performance
-      .getEntriesByName("https://example.com/resource.jpg", "resource")
-      // Get just the serverTiming array
-      .map(({ serverTiming }) => serverTiming);
-
-    serverEntries
-      // we only care about "slow" ones
-      filter({ duration }  => duration > 2.0)
-      // process just the attributes we are interested in
-      .forEach(({ name, duration, description }) => {
-        // ...
-      });
-
-    // Aternatively, we convert each into JSON
-    const entriesAsJson = serverEntries.map(entry => entry.toJSON());
+    window.performance
+      .getEntriesByName("https://example.com/resource.jpg", "resource")[0]
+      // Iterate over the serverTiming array
+      .serverTiming
+      .forEach({name, duration, description} => {
+        // we only care about "slow" ones
+        if (duration > 200) {
+          // ...
+        }
+      })
   </pre>
 </section>
 <section class='appendix informative'>

--- a/index.html
+++ b/index.html
@@ -255,17 +255,19 @@ Server must return the `Timing-Allow-Origin` HTTP response header, as defined in
 
   <pre class="example js">
     // serverTiming entries can live on 'navigation' and 'resource' entries
-    window.performance.getEntries()
-      // iterate over all entries
-      .forEach({name: url, entryType, serverTiming} => {
-        // iterate over the serverTiming array
-        (serverTiming || []).forEach({name, duration, description} => {
-          // we only care about "slow" ones
-          if (duration > 200) {
-            console.warn('Slow!', url, entryType, name, duration, description)
-          }
+    ['navigation', 'resource']
+      .forEach(function(entryType) {
+        performance.getEntriesByType(entryType).forEach(function({name: url, serverTiming}) {
+          // iterate over the serverTiming array
+          serverTiming.forEach(function({name, duration, description}) {
+            // we only care about "slow" ones
+            if (duration > 200) {
+              console.info('Slow server-timing entry =',
+                JSON.stringify({url, entryType, name, duration, description}, null, 2))
+            }
+          })
         })
-      })
+    })
   </pre>
 </section>
 <section class='appendix informative'>

--- a/index.html
+++ b/index.html
@@ -254,16 +254,17 @@ Server must return the `Timing-Allow-Origin` HTTP response header, as defined in
   <p>The application can collect, process, and act on the provided metrics via the provided JavaScript interface:</p>
 
   <pre class="example js">
-    // Gather server timing for a particular resource
-    window.performance
-      .getEntriesByName("https://example.com/resource.jpg", "resource")[0]
-      // Iterate over the serverTiming array
-      .serverTiming
-      .forEach({name, duration, description} => {
-        // we only care about "slow" ones
-        if (duration > 200) {
-          // ...
-        }
+    // serverTiming entries can live on 'navigation' and 'resource' entries
+    window.performance.getEntries()
+      // iterate over all entries
+      .forEach({name: url, entryType, serverTiming} => {
+        // iterate over the serverTiming array
+        (serverTiming || []).forEach({name, duration, description} => {
+          // we only care about "slow" ones
+          if (duration > 200) {
+            console.warn('Slow!', url, entryType, name, duration, description)
+          }
+        })
       })
   </pre>
 </section>


### PR DESCRIPTION
there were a few problems with the existing examples:
- missing `.` before `filter(`
- there is no `toJSON` on a server timing entry
- `serverTimings` was an array of arrays, so the `filter` wasn't quite right


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/cvazac/server-timing/examples.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/server-timing/7489b2a...cvazac:b2638ee.html)