### PR TITLE
Exclude PerformanceServerTiming objects for resources that fail the "timing allow check" algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,14 +171,9 @@ See [[!RFC7230]] for definitions of `#`, `OWS`, `token`, `DIGIT`, and `quoted-st
 <p>The user-agent MUST process <a>Server-Timing header field</a> communicated via a trailer field (see [[!RFC7230]] section 4.1.2) using the same algorithm.</p>
 
 ### Cross-origin Resources
-Cross-origin resources (i.e. non <a data-cite="!RFC6454#section-5">same origin</a>) MUST be included as <a>PerformanceServerTiming</a> objects in the <a data-cite="!PERFORMANCE-TIMELINE-2#sec-performance-timeline">Performance Timeline</a>. If the "timing allow check" algorithm, as defined in [[RESOURCE-TIMING-2]], fails for a cross-origin resource:
+Cross-origin resources (i.e. non <a data-cite="!RFC6454#section-5">same origin</a>) MUST be included as <a>PerformanceServerTiming</a> objects in the <a data-cite="!PERFORMANCE-TIMELINE-2#sec-performance-timeline">Performance Timeline</a> if the "timing allow check" algorithm, as defined in [[RESOURCE-TIMING-2]], passes. As the mere presence of a particularly named <a>PerformanceServerTiming</a> object is enough to communicate boolean information, if the "timing allow check" algorithm fails, the cross-origin resource MUST be excluded.
 
-<ul data-link-for="PerformanceServerTiming">
-  <li>The <a>duration</a> MUST be set to value 0.</li>
-  <li>The <a>description</a> MUST be set to an empty string.</li>
-</ul>
-
-Server must return the `Timing-Allow-Origin` HTTP response header, as defined in [[RESOURCE-TIMING-2]], to allow the user agent to fully expose, to the document origin(s) specified, the values of attributes that would have been set to zero or empty string due to the cross-origin restrictions.
+Servers must return the `Timing-Allow-Origin` HTTP response header, as defined in [[RESOURCE-TIMING-2]], to allow the user agent to fully expose, to the document origin(s) specified, the <a>PerformanceServerTiming</a> object that would have been excluded due to the cross-origin restrictions.
 </section>
 
 <section class='informative'>

--- a/index.html
+++ b/index.html
@@ -141,10 +141,16 @@ See [[!RFC7230]] for definitions of `#`, `OWS`, `token`, `DIGIT`, and `quoted-st
 ## Process
 
 ### Processing Model
-<p>When processing the response of the <a data-cite="NAVIGATION-TIMING-2#current-document">current document</a> call the <a>server-timing header parsing algorithm</a> with <var>resource timing object</var> set to the <a data-cite="NAVIGATION-TIMING-2#step-create-object">newly created</a> `PerformanceNavigationTiming` object.
+<p>When processing the response of the <a data-cite="NAVIGATION-TIMING-2#current-document">current document</a>, set the <a data-lt="PerformanceResourceTiming.serverTiming">serverTiming</a> attribute on the <a data-cite="NAVIGATION-TIMING-2#step-create-object">newly created</a> `PerformanceNavigationTiming` object to the return value of the <a>server-timing header parsing algorithm</a>
 </p>
 
-<p>For each resource <a data-cite="FETCH#concept-fetch">fetched</a> by the current <a href="https://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>, excluding resources fetched by cross-origin stylesheets fetched with <code>no-cors</code> policy, call the <a>server-timing header parsing algorithm</a> with <var>resource timing object</var> set to the <a data-cite="RESOURCE-TIMING-2#step-create-object">newly created</a> <a>PerformanceResourceTiming</a> object.
+<p>For each resource <a data-cite="FETCH#concept-fetch">fetched</a> by the current <a href="https://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>, excluding resources fetched by cross-origin stylesheets fetched with <code>no-cors</code> policy, set the <a data-lt="PerformanceResourceTiming.serverTiming">serverTiming</a> attribute on the <a data-cite="RESOURCE-TIMING-2#step-create-object">newly created</a> <a>PerformanceResourceTiming</a> object to:
+  <ol>
+    <li>If the "timing allow check" algorithm (as defined in [[RESOURCE-TIMING-2]]) passes, the return value of the <a>server-timing header parsing algorithm</a>
+    </li>
+    <li>An empty <a data-cite="WEBIDL#sequence">sequence</a>, otherwise.
+    </li>
+  </ol>
 </p>
 
 #### <dfn>server-timing header parsing algorithm</dfn>
@@ -163,17 +169,11 @@ See [[!RFC7230]] for definitions of `#`, `OWS`, `token`, `DIGIT`, and `quoted-st
       </li>
     </ol>
   </li>
-  <li>Set the <a data-lt="PerformanceResourceTiming.serverTiming">serverTiming</a> attribute on <var>resource timing object</var> to <var>entryList</var>.
-  </li>
+  <li>Return <var>entryList</var></li>
 </ol>
 
 <!-- TODO(cvazac) Should this be a MUST? -->
 <p>The user-agent MUST process <a>Server-Timing header field</a> communicated via a trailer field (see [[!RFC7230]] section 4.1.2) using the same algorithm.</p>
-
-### Cross-origin Resources
-Cross-origin resources (i.e. non <a data-cite="!RFC6454#section-5">same origin</a>) MUST be included as <a>PerformanceServerTiming</a> objects in the <a data-cite="!PERFORMANCE-TIMELINE-2#sec-performance-timeline">Performance Timeline</a> if the "timing allow check" algorithm, as defined in [[RESOURCE-TIMING-2]], passes. As the mere presence of a particularly named <a>PerformanceServerTiming</a> object is enough to communicate boolean information, if the "timing allow check" algorithm fails, the cross-origin resource MUST be excluded.
-
-Servers must return the `Timing-Allow-Origin` HTTP response header, as defined in [[RESOURCE-TIMING-2]], to allow the user agent to fully expose, to the document origin(s) specified, the <a>PerformanceServerTiming</a> object that would have been excluded due to the cross-origin restrictions.
 </section>
 
 <section class='informative'>


### PR DESCRIPTION
https://github.com/w3c/server-timing/issues/35


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/cvazac/server-timing/cvazac/tao.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/server-timing/1cd2d68...cvazac:58d0f44.html)