### PR TITLE
clarify extraneous characters after names

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,8 @@ To avoid any possible ambiguity, individual `server-timing-param-name`s SHOULD N
 
 User agents MUST ignore extraneous characters found after a `server-timing-param-value` but before the next `server-timing-param` and before the end of the current `server-timing-metric`.
 
+User agents MUST ignore extraneous characters found after a `metric-name` but before the first `server-timing-param` and before the next `server-timing-metric`.
+
 <p data-link-for="PerformanceServerTiming">
   This specification establishes the server-timing-params for server-timing-param-names <a data-lt="PerformanceServerTiming.duration">dur</a> and <a data-lt="PerformanceServerTiming.description">desc</a>, both optional.
 </p>


### PR DESCRIPTION
https://github.com/w3c/server-timing/issues/51


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cvazac/server-timing/pull/52.html" title="Last updated on Jan 19, 2018, 3:13 PM GMT (bf5d9f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/52/c39c51f...cvazac:bf5d9f5.html" title="Last updated on Jan 19, 2018, 3:13 PM GMT (bf5d9f5)">Diff</a>