### PR TITLE
Add example with both dur and desc

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,7 @@ User agents MUST ignore extraneous characters found after a `server-timing-param
     &lt; HTTP/1.1 200 OK
     &lt; Server-Timing: miss, db;dur=53, app;dur=47.2
     &lt; Server-Timing: customView, dc;desc=atl
+    &lt; Server-Timing: cache;desc="Cache Read";dur=23.2
     &lt; Trailer: Server-Timing
     &lt; (... snip response body ...)
     &lt; Server-Timing: total;dur=123.4
@@ -239,16 +240,18 @@ User agents MUST ignore extraneous characters found after a `server-timing-param
       <tr><td>app</td><td>47.2</td><td></td></tr>
       <tr><td>customView</td><td></td><td></td></tr>
       <tr><td>dc</td><td></td><td>atl</td></tr>
+      <tr><td>cache</td><td>23.2</td><td>Cache Read</td></tr>
       <tr><td>total</td><td>123.4</td><td></td></tr>
     </tbody>
   </table>
 
-  <p>The above header fields communicate five distinct metrics that illustrate all the possible ways for the server to communicate data to the user agent: metric name only, metric with value, metric with value and description, and metric with description. For example, the above metrics may indicate that for `example.com/resource.jpg` fetch:</p>
+  <p>The above header fields communicate six distinct metrics that illustrate all the possible ways for the server to communicate data to the user agent: metric name only, metric with value, metric with value and description, and metric with description. For example, the above metrics may indicate that for `example.com/resource.jpg` fetch:</p>
 
   <ol>
     <li>There was a cache miss.</li>
     <li>The request was routed through the "atl" datacenter ("dc").</li>
     <li>The database ("db") time was 53 ms.</li>
+    <li>A cache read took 23.2 ms.</li>
     <li>The application server ("app") took 47.2ms to process "customView" template or function.</li>
     <li>The total time for the request-response cycle on the server was 123.4ms, which is recorded at the end of the response and delivered via a trailer field.</li>
   </ol>


### PR DESCRIPTION
In [updating](https://gist.github.com/paulirish/a76ac17fc211b019e538c09d8d827691/revisions) my servertiming [demo file](https://gist.github.com/paulirish/a76ac17fc211b019e538c09d8d827691) to the new syntax I came to the spec for a readable example I could start with. The examples section doesn't really provide a single complete example, so I was hoping to fix that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulirish/server-timing/pull/53.html" title="Last updated on Feb 6, 2018, 9:57 PM GMT (d08b619)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/53/c39c51f...paulirish:d08b619.html" title="Last updated on Feb 6, 2018, 9:57 PM GMT (d08b619)">Diff</a>