### PR TITLE
Specify behavior for user-agents who only support secure contexts

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,10 +155,9 @@ User agents MUST ignore extraneous characters found after a `metric-name` but be
 
 <p>For each resource <a data-cite="FETCH#concept-fetch">fetched</a> by the current <a href="https://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>, excluding resources fetched by cross-origin stylesheets fetched with <code>no-cors</code> policy, set the <a data-lt="PerformanceResourceTiming.serverTiming">serverTiming</a> attribute on the <a data-cite="RESOURCE-TIMING-2#step-create-object">newly created</a> <a>PerformanceResourceTiming</a> object to:
   <ol>
-    <li>If the "timing allow check" algorithm (as defined in [[RESOURCE-TIMING-2]]) passes, the return value of the <a>server-timing header parsing algorithm</a>
-    </li>
-    <li>An empty <a data-cite="WEBIDL#sequence">sequence</a>, otherwise.
-    </li>
+    <li>An empty <a data-cite="WEBIDL#sequence">sequence</a>, if the return value from the "timing allow check" algorithm (as defined in [[RESOURCE-TIMING-2]]) is <code>fail</code>.</li>
+  <li>An empty <a data-cite="WEBIDL#sequence">sequence</a>, if the user agent chooses to limit their support to <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-contexts">secure contexts</a> and the <a data-link-type="dfn" href="https://w3c.github.io/resource-timing/#dfn-current-document">current document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> is not <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#is-settings-object-contextually-secure">contextually secure</a>.</li>
+    <li>The return value of the <a>server-timing header parsing algorithm</a>, otherwise.</li>
   </ol>
 </p>
 


### PR DESCRIPTION
https://github.com/w3c/server-timing/issues/54


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cvazac/server-timing/pull/59.html" title="Last updated on Oct 19, 2018, 7:42 PM GMT (532ca03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/59/e2382a7...cvazac:532ca03.html" title="Last updated on Oct 19, 2018, 7:42 PM GMT (532ca03)">Diff</a>