### PR TITLE
Trailer processing should be optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,8 +181,7 @@ User agents MUST ignore extraneous characters found after a `metric-name` but be
   <li>Return <var>entryList</var></li>
 </ol>
 
-<!-- TODO(cvazac) Should this be a MUST? -->
-<p>The user-agent MUST process <a>Server-Timing header field</a> communicated via a trailer field (see [[!RFC7230]] section 4.1.2) using the same algorithm.</p>
+<p>The user-agent MAY process <a>Server-Timing header field</a> communicated via a trailer field (see [[!RFC7230]] section 4.1.2) using the same algorithm.</p>
 </section>
 
 <section class='informative'>


### PR DESCRIPTION
Addresses https://github.com/w3c/server-timing/issues/58


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cvazac/server-timing/pull/60.html" title="Last updated on Oct 19, 2018, 6:32 PM GMT (38b5446)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/60/e2382a7...cvazac:38b5446.html" title="Last updated on Oct 19, 2018, 6:32 PM GMT (38b5446)">Diff</a>