### PR TITLE
Add conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,10 +60,12 @@
 <section class='informative'>
 ## Introduction
 
-Accurately measuring performance characteristics of web applications is an important aspect of making web applications faster. [[!NAVIGATION-TIMING-2]] and [[!RESOURCE-TIMING-2]] provide detailed request timing information for the document and its resources, which include time when the request was initiated, and various milestones to negotiate the connection and receive the response. However, while the user agent can observe the timing data of the request it has no insight into how or why certain stages of the request-response cycle have taken as much time as they have - e.g., how the request was routed, where the time was spent on the server, and so on.
+Accurately measuring performance characteristics of web applications is an important aspect of making web applications faster. [[NAVIGATION-TIMING-2]] and [[RESOURCE-TIMING-2]] provide detailed request timing information for the document and its resources, which include time when the request was initiated, and various milestones to negotiate the connection and receive the response. However, while the user agent can observe the timing data of the request it has no insight into how or why certain stages of the request-response cycle have taken as much time as they have - e.g., how the request was routed, where the time was spent on the server, and so on.
 
 This specification introduces <a>PerformanceServerTiming</a> interface, which enables the server to communicate performance metrics about the request-response cycle to the user agent, and a JavaScript interface to enable applications to collect, process, and act on these metrics to optimize application delivery.
 </section>
+
+<section id='conformance'></section>
 
 ### The `Server-Timing` Header Field
 


### PR DESCRIPTION
Fixes "Normative references in informative sections are not allowed" warning messages reported by Redpec.

The warnings appeared because Respec assumes that a spec is informative-only in the absence of a conformance section, see discussion in:
https://github.com/w3c/respec/issues/2580

Also fixes the References section as some of the specs were incorrectly listed as informative for the same reason.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/server-timing/pull/66.html" title="Last updated on Nov 21, 2019, 10:39 AM UTC (770ea91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/66/381cdbf...tidoust:770ea91.html" title="Last updated on Nov 21, 2019, 10:39 AM UTC (770ea91)">Diff</a>