### PR TITLE
chore: fix default toJSON linking error

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ User agents MUST ignore extraneous characters found after a `metric-name` but be
   };
   ```
 
-  When <dfn>toJSON</dfn> is called, run [[WEBIDL]]'s [=default toJSON operation=].
+  When <dfn>toJSON</dfn> is called, run [[WEBIDL]]'s [=default toJSON steps=].
 
   ### <dfn>name</dfn> attribute
   The {{name}} attribute MUST return the DOMString value of the server-specified metric name.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/server-timing/pull/76.html" title="Last updated on Jul 10, 2020, 2:36 PM UTC (634a4f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/76/36c2e8b...sidvishnoi:634a4f3.html" title="Last updated on Jul 10, 2020, 2:36 PM UTC (634a4f3)">Diff</a>