### PR TITLE
Allow user agents to keep same-origin restrictions on PerformanceServ…

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@ To <dfn>parse a server-timing header field</dfn> given a string |field|:
 <section class='informative'>
   ## Privacy and Security
 
-  The interfaces defined in this specification expose potentially sensitive application and infrastructure information to any web page that has included a resource that advertises server timing metrics. For this reason the access to `PerformanceServerTiming` interface is restricted by the [=same origin=] policy by default. Resource providers can explicitly allow server timing information to be available by adding the `Timing-Allow-Origin` HTTP response header, as defined in [[RESOURCE-TIMING]], that specifies the domains that are allowed to access the server metrics.
+  The interfaces defined in this specification expose potentially sensitive application and infrastructure information to any web page that has included a resource that advertises server timing metrics. For this reason the access to `PerformanceServerTiming` interface is restricted by the [=same origin=] policy by default. Resource providers can explicitly allow server timing information to be available by adding the `Timing-Allow-Origin` HTTP response header, as defined in [[RESOURCE-TIMING]], that specifies the domains that may be allowed to access the server metrics, but the user agent MAY keep the [=same origin=] policy restriction.
 
   In addition to using the `Timing-Allow-Origin` HTTP response header, the server can also use relevant logic to control which metrics are returned, when, and to whom - e.g. the server may only provide certain metrics to correctly authenticated users and nothing at all to all others.
 </section>


### PR DESCRIPTION
…erTiming

even with the presence of TAO header fields.  This resolves https://github.com/w3c/server-timing/issues/89


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/achristensen07/server-timing/pull/90.html" title="Last updated on Jan 26, 2023, 4:49 AM UTC (ceda8f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/90/4763cb7...achristensen07:ceda8f9.html" title="Last updated on Jan 26, 2023, 4:49 AM UTC (ceda8f9)">Diff</a>