### PR TITLE
Fix broken references to INFRA#map.

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ To <dfn>parse a server-timing header field</dfn> given a string |field|:
 
 1. Let |metric| be a new {{PerformanceServerTiming}} whose <a data-for="PerformanceServerTiming">metric name</a> is |name|.
 
-1. Let |params| be an empty <a data-cite="INFRA#map">map</a>.
+1. Let |params| be an empty <a>ordered map</a>.
 
 1. While |position| is not at the end of |field|:
 
@@ -187,7 +187,7 @@ To <dfn>parse a server-timing header field</dfn> given a string |field|:
 
   A {{PerformanceServerTiming}} has an associated string <dfn>metric name</dfn>, initially set to the empty string.
 
-  A {{PerformanceServerTiming}} has an associated <a data-cite="INFRA#map">map</a> <dfn>params</dfn>, initially empty.
+  A {{PerformanceServerTiming}} has an associated <a>ordered map</a> <dfn>params</dfn>, initially empty.
 </section>
 
 <!-- TODO: How do extend and cross-reference the interface? -->


### PR DESCRIPTION
This replaces those references with valid refs to "ordered map".

Closes: #91


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/pull/92.html" title="Last updated on Mar 17, 2023, 3:12 PM UTC (ac1b815)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/92/2807e9b...ac1b815.html" title="Last updated on Mar 17, 2023, 3:12 PM UTC (ac1b815)">Diff</a>