### PR TITLE
Add `[SecureContext]` tag to the interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ To <dfn>parse a server-timing header field</dfn> given a string |field|:
   ## The <dfn>PerformanceServerTiming</dfn> Interface
 
   ``` webidl
-  [Exposed=(Window,Worker)]
+  [Exposed=(Window,Worker), SecureContext]
   interface PerformanceServerTiming {
     readonly attribute DOMString name;
     readonly attribute DOMHighResTimeStamp duration;


### PR DESCRIPTION
- addresses https://github.com/w3c/webref/issues/1142#issuecomment-1924200755

`w3c/webref` repo automatically extracts syntaxes from these spec docs. At the moment a syntax section is missing the `[SecureContext]` tag so it is [missing from extracted data in webref as well](https://github.com/w3c/webref/blob/1ebc07b4638f130623f054e556da62fd6a045e01/ed/idl/server-timing.idl#L6).

The feature has been [marked available in secure context in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming). 

The PR adds the tag to the interface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 5, 2024, 2:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
📡 HTTP Error 404: http://localhost:8082/spec-generator/uploads/Q8xCqS/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/server-timing%2394.)._
</details>
