### PR TITLE
Fix broken reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@ To <dfn>parse a server-timing header field</dfn> given a string |field|:
 <section data-dfn-for="PerformanceResourceTiming" data-link-for="PerformanceResourceTiming">
   ### Extension to the {{PerformanceResourceTiming}} interface
 
-  The <dfn data-cite="RESOURCE-TIMING#performanceresourcetiming">PerformanceResourceTiming</dfn> interface, which this specification partially extends, is defined in [[RESOURCE-TIMING]].
+  The {{PerformanceResourceTiming}} interface, which this specification partially extends, is defined in [[RESOURCE-TIMING]].
 
   ``` webidl
   [Exposed=(Window,Worker)]


### PR DESCRIPTION
This fixes a broken reference to the PerformanceResourceTiming interface.

Closes: #96


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/server-timing/pull/97.html" title="Last updated on May 23, 2024, 6:07 PM UTC (0e49285)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/server-timing/97/02dc62d...clelland:0e49285.html" title="Last updated on May 23, 2024, 6:07 PM UTC (0e49285)">Diff</a>